### PR TITLE
fix: Eventloop unclosed

### DIFF
--- a/src/ragas/executor.py
+++ b/src/ragas/executor.py
@@ -96,7 +96,7 @@ class Runner(threading.Thread):
             results = self.loop.run_until_complete(self._aresults())
         finally:
             self.results = results
-            self.loop.stop()
+            self.loop.close()
 
 
 @dataclass


### PR DESCRIPTION
When I call ragas in the fastapi, every time I call it, python will have an open event loop (/proc/self/fd).